### PR TITLE
Added support to 1.21.7 and other enhancements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.4
-loader_version=0.16.9
+minecraft_version=1.21.7
+yarn_mappings=1.21.7+build.4
+loader_version=0.16.14
 
 # Fabric API
-fabric_version=0.113.0+1.21.4
+fabric_version=0.128.2+1.21.7
 
 # Mod Properties
 mod_version=1.1

--- a/src/main/java/com/bouncingelf10/animatedLogo/AnimatedLogo.java
+++ b/src/main/java/com/bouncingelf10/animatedLogo/AnimatedLogo.java
@@ -19,7 +19,7 @@ public class AnimatedLogo implements ModInitializer {
 
     @Override
     public void onInitialize() {
-        LOGGER.info("[Animated Mojang Logo] Initializing Startup Animation, DLS: {}", !isDarkLoadingScreenNotPresent());
+        LOGGER.info("Initializing Startup Animation, DLS: {}", !isDarkLoadingScreenNotPresent());
         Registry.register(Registries.SOUND_EVENT, STARTUP_SOUND_ID, STARTUP_SOUND_EVENT);
     }
 }

--- a/src/main/java/com/bouncingelf10/animatedLogo/DarkLoadingScreenCompat.java
+++ b/src/main/java/com/bouncingelf10/animatedLogo/DarkLoadingScreenCompat.java
@@ -17,7 +17,7 @@ public class DarkLoadingScreenCompat {
             Object config = configClass.getMethod("read").invoke(null);
             return configClass.getField("bar").getInt(config);
         } catch (Exception e) {
-            LOGGER.error("[Animated Mojang Logo] Failed to access Dark Loading Screen config", e);
+            LOGGER.error("Failed to access Dark Loading Screen config", e);
             return fallback;
         }
     }
@@ -30,7 +30,7 @@ public class DarkLoadingScreenCompat {
             Object config = configClass.getMethod("read").invoke(null);
             return configClass.getField("border").getInt(config);
         } catch (Exception e) {
-            LOGGER.error("[Animated Mojang Logo] Failed to access Dark Loading Screen config", e);
+            LOGGER.error("Failed to access Dark Loading Screen config", e);
             return fallback;
         }
     }
@@ -43,7 +43,7 @@ public class DarkLoadingScreenCompat {
             Object config = configClass.getMethod("read").invoke(null);
             return configClass.getField("logo").getInt(config);
         } catch (Exception e) {
-            LOGGER.error("[Animated Mojang Logo] Failed to access Dark Loading Screen config", e);
+            LOGGER.error("Failed to access Dark Loading Screen config", e);
             return fallback;
         }
     }

--- a/src/main/java/com/bouncingelf10/animatedLogo/mixin/SplashOverlayMixin.java
+++ b/src/main/java/com/bouncingelf10/animatedLogo/mixin/SplashOverlayMixin.java
@@ -4,9 +4,9 @@ import com.bouncingelf10.animatedLogo.AnimatedLogo;
 import com.bouncingelf10.animatedLogo.DarkLoadingScreenCompat;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.SplashOverlay;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.sound.*;
 import net.minecraft.resource.ResourceReload;
 import net.minecraft.util.Identifier;
@@ -106,13 +106,13 @@ public class SplashOverlayMixin {
 
     // Stop rendering of title
     @ModifyArg(method = "render",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIFFIIIIIII)V", ordinal = 0),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/util/Identifier;IIFFIIIIIII)V", ordinal = 0),
             index = 7)
     private int removeText1(int i) {
         return 0;
     }
     @ModifyArg(method = "render",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIFFIIIIIII)V", ordinal = 1),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/util/Identifier;IIFFIIIIIII)V", ordinal = 1),
             index = 7)
     private int removeText2(int u) {
         return 0;
@@ -132,7 +132,7 @@ public class SplashOverlayMixin {
         long elapsed = System.currentTimeMillis() - animationDelayStartTime;
 
         if (elapsed < ANIMATION_DELAY_MS) {
-            context.fill(RenderLayer.getGuiOverlay(), 0, 0,
+            context.fill(RenderPipelines.GUI, 0, 0,
                     context.getScaledWindowWidth(), context.getScaledWindowHeight(),
                     ColorHelper.withAlpha((int)((elapsed * 255) / ANIMATION_DELAY_MS / 10),
                             applyAlphaToColor(BRAND_ARGB.getAsInt(), 1.0f)));
@@ -150,7 +150,7 @@ public class SplashOverlayMixin {
     private void drawAnimatedIntro(DrawContext context) {
         if (!reload.isComplete() && !isFadingOut && !isFadingFinished) {
 
-            context.fill(RenderLayer.getGuiOverlay(), 0, 0,
+            context.fill(RenderPipelines.GUI, 0, 0,
                     context.getScaledWindowWidth(), context.getScaledWindowHeight(),
                     applyAlphaToColor(BRAND_ARGB.getAsInt(), 1.0f));
 
@@ -169,7 +169,7 @@ public class SplashOverlayMixin {
             long elapsedFade = System.currentTimeMillis() - fadeOutStartTime;
             float fadeFactor = 1.0f - MathHelper.clamp((float)elapsedFade / FADE_OUT_DURATION_MS, 0.0f, 1.0f);
 
-            context.fill(RenderLayer.getGuiOverlay(), 0, 0,
+            context.fill(RenderPipelines.GUI, 0, 0,
                     context.getScaledWindowWidth(), context.getScaledWindowHeight(),
                     applyAlphaToColor(BRAND_ARGB.getAsInt(), 1.0f));
 
@@ -226,18 +226,19 @@ public class SplashOverlayMixin {
             int frameIndex = count / IMAGE_PER_FRAME / FRAMES_PER_FRAME;
             int subFrameY = 256 * ((count % (IMAGE_PER_FRAME * FRAMES_PER_FRAME)) / FRAMES_PER_FRAME);
 
-            context.fill(RenderLayer.getGuiOverlay(), 0, 0,
+            context.fill(RenderPipelines.GUI, 0, 0,
                     context.getScaledWindowWidth(), context.getScaledWindowHeight(),
                     applyAlphaToColor(BRAND_ARGB.getAsInt(), 1.0f));
 
-            context.drawTexture(RenderLayer::getGuiTextured, frames[frameIndex], x, y,
+            context.drawTexture(RenderPipelines.GUI_TEXTURED, frames[frameIndex], x, y,
                     0, subFrameY, width, height,
                     1024, 256, 1024, 1024, applyAlphaToColor(TEXT_COLOR.getAsInt(), 1.0f));
         }
     }
 
+    // TODO
     @Inject(method = "render", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIFFIIIIIII)V",
+            target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/util/Identifier;IIFFIIIIIII)V",
             ordinal = 1, shift = At.Shift.AFTER))
     private void onAfterRenderLogo(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci,
                                    @Local(ordinal = 2) int scaledWidth, @Local(ordinal = 3) int scaledHeight,
@@ -251,7 +252,7 @@ public class SplashOverlayMixin {
         if (progress >= 0.8) {
             f = Math.min(alpha, f + 0.2f);
             int sw = (int) (width * 0.45);
-            context.drawTexture(RenderLayer::getGuiTextured, Identifier.of("animated-mojang-logo", "textures/gui/studios.png"),
+            context.drawTexture(RenderPipelines.GUI_TEXTURED, Identifier.of("animated-mojang-logo", "textures/gui/studios.png"),
                     x - sw / 2, (int) (y - halfHeight + height - height / 12),
                     0, 0, sw, (int) (height / 5.0), 450, 50, 512, 512, applyAlphaToColor(TEXT_COLOR.getAsInt(), f));
         }
@@ -266,7 +267,7 @@ public class SplashOverlayMixin {
         int finalSubFrameY = 256 * ((count % (IMAGE_PER_FRAME * FRAMES_PER_FRAME)) / FRAMES_PER_FRAME);
 
         Identifier finalFrame = frames[FRAMES - 1];
-        context.drawTexture(RenderLayer::getGuiTextured, finalFrame, finalFrameX, finalFrameY,
+        context.drawTexture(RenderPipelines.GUI_TEXTURED, finalFrame, finalFrameX, finalFrameY,
                 0, finalSubFrameY, finalFrameWidth, finalFrameHeight,
                 1024, 256, 1024, 1024, applyAlphaToColor(TEXT_COLOR.getAsInt(), alpha));
     }

--- a/src/main/java/com/bouncingelf10/animatedLogo/mixin/SplashOverlayMixin.java
+++ b/src/main/java/com/bouncingelf10/animatedLogo/mixin/SplashOverlayMixin.java
@@ -24,6 +24,7 @@ import java.util.function.IntSupplier;
 import static com.bouncingelf10.animatedLogo.AnimatedLogo.LOGGER;
 
 @Mixin(SplashOverlay.class)
+@SuppressWarnings({"FieldMayBeFinal","unused"})
 public class SplashOverlayMixin {
     @Mutable
     @Shadow @Final private ResourceReload reload;
@@ -236,7 +237,6 @@ public class SplashOverlayMixin {
         }
     }
 
-    // TODO
     @Inject(method = "render", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/util/Identifier;IIFFIIIIIII)V",
             ordinal = 1, shift = At.Shift.AFTER))

--- a/src/main/java/com/bouncingelf10/animatedLogo/mixin/SplashOverlayMixin.java
+++ b/src/main/java/com/bouncingelf10/animatedLogo/mixin/SplashOverlayMixin.java
@@ -192,7 +192,7 @@ public class SplashOverlayMixin {
                 MinecraftClient.getInstance().getSoundManager().play(
                         PositionedSoundInstance.master(AnimatedLogo.STARTUP_SOUND_EVENT, 1.0F)
                 );
-                LOGGER.info("[Animated Mojang Logo] Playing startup sound");
+                LOGGER.info("Playing startup sound");
                 soundPlayed = true;
             }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.5",
-    "minecraft": ">=1.21.2",
+    "minecraft": "1.21.7",
     "java": ">=21",
     "fabric-api": "*"
   },


### PR DESCRIPTION
I updated the mod to run on 1.21.7. I also made some enhancements...
I removed the prefix in the logs as it is redundant:
**Before:** `[00:30:13] [Render thread] [animated-mojang-logo/INFO]: [Animated Mojang Logo] Playing startup sound`
**After:** `[00:30:13] [Render thread] [animated-mojang-logo/INFO]: Playing startup sound`
And I also made it so that `unused` and `FieldMayBeFinal` certain warnings are ignored.